### PR TITLE
portal-router: close stale host control sockets

### DIFF
--- a/crates/portal-client/src/lib.rs
+++ b/crates/portal-client/src/lib.rs
@@ -266,6 +266,9 @@ impl TunnelHost {
                 Message::Binary(_) => {
                     tracing::warn!("ignoring binary message on host control socket");
                 }
+                Message::Close(Some(close)) => {
+                    tracing::info!("control socket closed: {close}");
+                }
                 // Ignore all other message types.
                 msg => {
                     tracing::trace!("incoming ws message {msg:?}");


### PR DESCRIPTION
If a host connects but we have a previous host control socket, close it. This may improve situations where the previous socket appears unresponsive, and can take a while to die off on its own.

Add a code and reason message to the close, and log them in the host code. This will help if a host gets cloned and are caught it a loop bumping each other off the portal.