### PR TITLE
send close when DO receives a close

### DIFF
--- a/crates/portal-router/src/durable.rs
+++ b/crates/portal-router/src/durable.rs
@@ -212,6 +212,10 @@ impl DurableRouter {
                 Err(_) => console_log!("unrecognized tag {tag}"),
             }
         }
+        // Respond to any closing request we receive. This ensures that the websockets don't linger in a closing state.
+        if let Err(e) = ws.close(Some(1000), Some("Durable Object is closing WebSocket")) {
+            console_log!("error while closing websocket: {e}");
+        }
     }
 
     fn close_peer(&mut self, tag: SocketTag) {


### PR DESCRIPTION
We receive a lot of unexpected close 1006 that triggers this code path and we should be responding to them. Otherwise, if we don't, the socket is left in closing state. Also, mimics the Cloudflare example: https://developers.cloudflare.com/durable-objects/best-practices/websockets/#websocket-hibernation-api 