### PR TITLE
Try sending on every host control socket until we find an open one

### DIFF
--- a/crates/portal-router/src/durable.rs
+++ b/crates/portal-router/src/durable.rs
@@ -47,8 +47,8 @@ struct SocketInfo {
 }
 
 impl SocketInfo {
-    fn to_tags(&self) -> Vec<String> {
-        vec![
+    fn to_tags(&self) -> [String; 2] {
+        [
             format!("portal-id-{}", self.portal_id),
             self.socket_tag.to_string(),
         ]
@@ -344,10 +344,8 @@ impl DurableRouter {
             socket_tag: SocketTag::HostControl,
         };
         let tags = socket_info.to_tags();
-        self.state.accept_websocket_with_tags(
-            &server_ws,
-            &tags.iter().map(|tag| tag.as_str()).collect::<Vec<_>>(),
-        );
+        self.state
+            .accept_websocket_with_tags(&server_ws, tags.each_ref().map(String::as_str).as_slice());
 
         if let Err(e) = Self::send_message(
             &server_ws,
@@ -391,7 +389,7 @@ impl DurableRouter {
         let tags = socket_info.to_tags();
         self.state.accept_websocket_with_tags(
             &server_ws,
-            &tags.iter().map(|tag| tag.as_str()).collect::<Vec<_>>(),
+            &tags.each_ref().map(String::as_str).as_slice(),
         );
 
         // Inform the client that the connection is established, so it
@@ -434,7 +432,7 @@ impl DurableRouter {
         let tags = socket_info.to_tags();
         self.state.accept_websocket_with_tags(
             &server_ws,
-            &tags.iter().map(|tag| tag.as_str()).collect::<Vec<_>>(),
+            &tags.each_ref().map(String::as_str).as_slice(),
         );
 
         // Loop over all host sockets until a send is successful.

--- a/crates/portal-router/src/durable.rs
+++ b/crates/portal-router/src/durable.rs
@@ -67,6 +67,7 @@ impl TryFrom<Vec<String>> for SocketInfo {
         for tag in tags {
             if let Some(pid) = tag.strip_prefix("portal-id-") {
                 let prev = portal_id.replace(pid.to_owned());
+                // We only expect one portal id tag
                 if let Some(prev) = prev {
                     console_log!("multiple portal id tags found, ignoring {prev}");
                 }
@@ -76,6 +77,7 @@ impl TryFrom<Vec<String>> for SocketInfo {
             match tag.parse::<SocketTag>() {
                 Ok(st) => {
                     let prev = socket_tag.replace(st);
+                    // We only expect one socket type tag
                     if let Some(prev) = prev {
                         console_log!("multiple socket tags found, ignoring {prev}");
                     }
@@ -493,6 +495,8 @@ impl DurableRouter {
             }
             WebSocketIncomingMessage::Binary(msg) => {
                 let client_tag = SocketTag::ClientData(nexus);
+                // We only expect one client socket since a nexus is randomly generated for each connection.
+                // If there are multiple, we log a warning in find_websockets.
                 let Some(client_socket) = self.find_websockets(&client_tag).into_iter().next()
                 else {
                     console_log!("client socket {client_tag} not found");
@@ -523,6 +527,8 @@ impl DurableRouter {
             }
             WebSocketIncomingMessage::Binary(msg) => {
                 let host_tag = SocketTag::HostData(nexus);
+                // We only expect one host socket since a nexus is randomly generated for each connection.
+                // If there are multiple, we log a warning in find_websockets.
                 let Some(host_socket) = self.find_websockets(&host_tag).into_iter().next() else {
                     console_log!("host socket {host_tag} not found");
                     return Err(ProtocolError::PeerBroken);


### PR DESCRIPTION
Until we know the root cause for why we have closed host control sockets lingering, we can try sending on every hc socket until we find an open one. This should mitigate the send() after close() issue that causes a TimedOut UNLESS we are getting to a state where we only have closing hc sockets and no open ones. 

Also, added portal id for logging

Tested locally to make sure core functionality still works using the tcp forwarding example. 