### PR TITLE
Add logging + error reponse

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -942,6 +942,7 @@ name = "matic-portal"
 version = "0.1.0"
 dependencies = [
  "matic-portal-client",
+ "matic-portal-types",
 ]
 
 [[package]]

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -59,3 +59,4 @@ jwt-webcrypto = { path = "jwt-webcrypto" }
 
 [dependencies]
 matic-portal-client.path = "portal-client"
+matic-portal-types.path = "portal-types"

--- a/crates/portal-router/src/durable.rs
+++ b/crates/portal-router/src/durable.rs
@@ -253,7 +253,11 @@ impl DurableRouter {
         let socket_info = SocketInfo::try_from_tags(tags)
             .map_err(|_| worker::Error::RustError("missing peer and/or portal id".into()))?;
 
-        console_log!("socket closed on portal id {}", socket_info.portal_id);
+        console_log!(
+            "socket {} closed on portal id {}",
+            socket_info.socket_tag,
+            socket_info.portal_id
+        );
 
         match socket_info.socket_tag {
             SocketTag::HostControl => {
@@ -463,6 +467,7 @@ impl DurableRouter {
 
         if !delivered {
             console_log!("failed to send incoming message to any host socket");
+            return Response::error("tunnel host not available: no open connections", 503);
         }
 
         if let Err(e) = Self::send_message(

--- a/crates/src/lib.rs
+++ b/crates/src/lib.rs
@@ -1,1 +1,2 @@
 pub use matic_portal_client as client;
+pub use matic_portal_types as types;


### PR DESCRIPTION
Started logging which control socket closed to help debug issue where socket closes and we don't know which one: https://maticrobots.slack.com/archives/C0953MKK3RA/p1759177598009379?thread_ts=1759172552.378859&cid=C0953MKK3RA. Added explicit response for no open socket case so client is aware of it. 

Also exposed matic-portal-types so it can be used in the main repo: https://github.com/MaticianInc/matic/pull/23035.